### PR TITLE
[Nightly 2026-02-10] WebSocket 재연결 타이머 및 파일 스트림 에러 처리

### DIFF
--- a/packages/naite-viewer/src/lib/connection.ts
+++ b/packages/naite-viewer/src/lib/connection.ts
@@ -40,6 +40,10 @@ function connect() {
   ws.onclose = () => {
     console.log("[naite-viewer] WebSocket disconnected, reconnecting...");
     ws = null;
+    // 기존 타이머가 있으면 정리 후 새 타이머 설정 (중복 실행 방지)
+    if (reconnectTimer) {
+      clearTimeout(reconnectTimer);
+    }
     reconnectTimer = setTimeout(connect, 2000);
   };
 

--- a/packages/sonamu-lsp/src/viewer/viewer-server.ts
+++ b/packages/sonamu-lsp/src/viewer/viewer-server.ts
@@ -53,7 +53,13 @@ export function startViewerServer(): void {
     };
 
     res.writeHead(200, { "Content-Type": mimeTypes[ext] || "application/octet-stream" });
-    fs.createReadStream(filePath).pipe(res);
+    const stream = fs.createReadStream(filePath);
+    stream.on("error", (err) => {
+      console.error("[Viewer Server] File stream error:", err);
+      // 헤더가 이미 전송되었으므로 연결만 종료
+      res.end();
+    });
+    stream.pipe(res);
   });
 
   // WebSocket 서버

--- a/packages/vscode-extension/src/naite/features/inline-value-display/value-decorator.ts
+++ b/packages/vscode-extension/src/naite/features/inline-value-display/value-decorator.ts
@@ -3,16 +3,11 @@ import type vscode from "vscode";
 // 인라인 값 표시는 이제 LSP의 inlay hints로 처리됩니다.
 // 이 파일은 하위 호환을 위해 빈 구현을 유지합니다.
 
-let inlineValueDecorationType: vscode.TextEditorDecorationType | null = null;
-
 export function updateInlineValueDecorations(_editor: vscode.TextEditor) {
   // LSP inlay hints가 인라인 값 표시를 담당합니다.
   // 추후 LSP에서 제공하지 않는 추가적인 데코레이션이 필요할 경우 여기에 구현합니다.
 }
 
 export function disposeInlineValueDecorations() {
-  if (inlineValueDecorationType) {
-    inlineValueDecorationType.dispose();
-    inlineValueDecorationType = null;
-  }
+  // 현재 decoration이 없으므로 정리할 것이 없습니다.
 }


### PR DESCRIPTION
## Summary

- naite-viewer의 WebSocket 재연결 타이머가 중복 실행될 수 있는 문제 수정
- sonamu-lsp viewer-server에서 파일 스트림 에러 처리 누락 수정
- vscode-extension에서 미사용 변수 정리

## What Changed

### packages/naite-viewer/src/lib/connection.ts
- `onclose` 핸들러에서 기존 `reconnectTimer`가 있으면 먼저 정리 후 새 타이머 설정
- 여러 번의 `onclose` 이벤트가 빠르게 발생할 경우 타이머가 중복 생성되는 것을 방지

### packages/sonamu-lsp/src/viewer/viewer-server.ts
- `fs.createReadStream(filePath).pipe(res)` 에서 스트림 에러 핸들러 추가
- 파일 읽기 실패 시 로그를 남기고 응답을 정상적으로 종료

### packages/vscode-extension/src/naite/features/inline-value-display/value-decorator.ts
- 생성되지 않는 `inlineValueDecorationType` 변수 제거
- 빈 dispose 함수의 불필요한 null 체크 로직 제거

## Why

1. **타이머 중복 방지**: 네트워크 불안정 상황에서 `onclose`가 여러 번 호출될 수 있고, 각 호출마다 새 타이머가 생성되면 다수의 재연결 시도가 동시에 일어날 수 있음
2. **에러 핸들링**: `fs.createReadStream`의 에러를 처리하지 않으면 `ENOENT` 등의 에러가 uncaught exception으로 전파될 수 있음
3. **죽은 코드 제거**: 생성되지 않는 변수를 체크하는 코드는 불필요하며, 코드 가독성을 저해함

## Test Plan

- [x] 린트 통과
- [x] 빌드 성공
- [x] 테스트 통과 (sonamu-lsp)
- [ ] naite-viewer에서 네트워크 연결 끊김/복구 시 재연결 정상 동작 확인
- [ ] viewer-server에서 존재하지 않는 파일 요청 시 에러 처리 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)