### PR TITLE
[Nightly 2026-02-11] naite-viewer WebSocket 재연결 타이머 정리 및 연결 해제 함수 추가

### DIFF
--- a/packages/naite-viewer/src/lib/connection.ts
+++ b/packages/naite-viewer/src/lib/connection.ts
@@ -8,10 +8,22 @@ type MessageHandler = (data: unknown) => void;
 let ws: WebSocket | null = null;
 let messageHandlers: MessageHandler[] = [];
 let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+let isDisconnecting = false;
 
 const WS_URL = `ws://${window.location.hostname}:${window.location.port || "3400"}/ws`;
 
+function clearReconnectTimer(): void {
+  if (reconnectTimer) {
+    clearTimeout(reconnectTimer);
+    reconnectTimer = null;
+  }
+}
+
 function connect() {
+  if (isDisconnecting) {
+    return;
+  }
+
   if (ws && (ws.readyState === WebSocket.OPEN || ws.readyState === WebSocket.CONNECTING)) {
     return;
   }
@@ -20,10 +32,7 @@ function connect() {
 
   ws.onopen = () => {
     console.log("[naite-viewer] WebSocket connected");
-    if (reconnectTimer) {
-      clearTimeout(reconnectTimer);
-      reconnectTimer = null;
-    }
+    clearReconnectTimer();
   };
 
   ws.onmessage = (event) => {
@@ -38,8 +47,12 @@ function connect() {
   };
 
   ws.onclose = () => {
+    if (isDisconnecting) {
+      return;
+    }
     console.log("[naite-viewer] WebSocket disconnected, reconnecting...");
     ws = null;
+    clearReconnectTimer();
     reconnectTimer = setTimeout(connect, 2000);
   };
 
@@ -49,7 +62,21 @@ function connect() {
 }
 
 export function initConnection() {
+  isDisconnecting = false;
   connect();
+}
+
+/**
+ * WebSocket 연결 해제 및 재연결 타이머 정리
+ * 앱 언마운트 시 호출하여 리소스를 정리합니다.
+ */
+export function disconnectConnection(): void {
+  isDisconnecting = true;
+  clearReconnectTimer();
+  if (ws) {
+    ws.close();
+    ws = null;
+  }
 }
 
 export function sendMessage(message: unknown) {

--- a/packages/naite-viewer/src/main.tsx
+++ b/packages/naite-viewer/src/main.tsx
@@ -2,10 +2,15 @@ import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import App from "./App";
 import "naite-trace-viewer/index.css";
-import { initConnection } from "./lib/connection";
+import { disconnectConnection, initConnection } from "./lib/connection";
 
 // WebSocket 연결 초기화
 initConnection();
+
+// 페이지 언로드 시 WebSocket 연결 정리
+window.addEventListener("beforeunload", () => {
+  disconnectConnection();
+});
 
 const root = document.getElementById("root");
 if (root) {


### PR DESCRIPTION
## 🤖 AI 생성 PR 안내

이 PR은 AI(Claude Code)가 코드베이스를 분석하여 생성한 Nightly PR입니다.
#6(Nightly PR Directions)과 #7(내일 새벽에 AI에게 맡길 일들)의 지침을 따라 작업했습니다.

---

## Summary

- naite-viewer 패키지의 WebSocket 연결 관리에서 재연결 타이머가 정리되지 않는 문제 수정
- 페이지 언마운트 시 리소스를 정리하는 `disconnectConnection()` 함수 추가

---

## 상세 내용

### packages/naite-viewer/src/lib/connection.ts

**문제점**:
- 기존 코드에서는 페이지 언로드 시 WebSocket 연결을 정리하는 방법이 없었음
- `onclose` 핸들러에서 항상 재연결 타이머를 설정하므로, 의도적인 연결 해제와 네트워크 끊김을 구분할 수 없었음
- 타이머 정리 로직이 중복되어 있었음

**수정 내용**:
1. `isDisconnecting` 플래그 추가: 의도적인 연결 해제인지 구분
2. `clearReconnectTimer()` 헬퍼 함수: 타이머 정리 로직 중앙화
3. `disconnectConnection()` 함수 export: 외부에서 연결 종료 가능
4. `connect()` 함수에서 `isDisconnecting` 체크: 연결 해제 중에는 재연결 시도 안 함
5. `initConnection()`에서 `isDisconnecting = false` 설정: 재초기화 가능

### packages/naite-viewer/src/main.tsx

- `beforeunload` 이벤트 리스너 추가
- 페이지 언로드 시 `disconnectConnection()` 호출

---

## 이 PR의 대상 선정 근거

Issue #7에 명시된 "잠재적으로 위험한 포인트 식별" 지침에 따라 분석했습니다:
- 페이지 닫힘 시에도 WebSocket 재연결 타이머가 남아있으면 불필요한 리소스 점유
- 특히 SPA에서 라우팅으로 컴포넌트가 언마운트될 때 타이머가 정리되지 않으면 메모리 누수 발생 가능

---

## 변경하지 않으면 어떤 점이 안 좋은지

1. **좀비 타이머**: 페이지가 닫혀도 재연결 타이머가 계속 실행됨
2. **불필요한 연결 시도**: 사용자가 의도적으로 페이지를 떠났는데도 재연결을 시도
3. **리소스 낭비**: 타이머와 WebSocket 객체가 정리되지 않아 메모리 점유

---

## 영향 범위

- **기능적 영향**: naite-viewer 독립 웹앱에서만 적용 (VSCode 웹뷰와는 무관)
- **하위 호환성**: 기존 API 유지, 새로운 함수만 추가
- **타입 체크**: ✅ 통과
- **린트**: ✅ 통과
- **빌드**: ✅ 통과

---

## 확인 방법

1. naite-viewer를 브라우저에서 열기
2. 개발자 도구에서 WebSocket 연결 확인
3. 페이지를 닫거나 새로고침할 때 콘솔 로그 확인
4. 재연결 타이머가 정리되고 불필요한 연결 시도가 없는지 확인

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)