### PR TITLE
[Nightly 2026-02-12] 에러 핸들링 개선 및 타이머 정리

### DIFF
--- a/packages/sonamu-lsp/src/core/trace-store.ts
+++ b/packages/sonamu-lsp/src/core/trace-store.ts
@@ -24,8 +24,16 @@ class TraceStoreClass {
     }, this.TEST_RESULT_ADDED_DEBOUNCE_DELAY);
   }
 
+  /**
+   * NaiteSocketServer에서 "run/end" 메시지 수신 시 호출됩니다.
+   * 남아있는 디바운스 타이머를 정리하고, 마지막 알림을 즉시 발송합니다.
+   */
   addRunEnd(): void {
-    // 현재는 처리할 작업 없음
+    if (this.testResultAddedDebounceTimer) {
+      clearTimeout(this.testResultAddedDebounceTimer);
+      this.testResultAddedDebounceTimer = null;
+      this.notifyTestResultAdded();
+    }
   }
 
   getAllTestResults(): NaiteMessagingTypes.TestResult[] {

--- a/packages/vscode-extension/src/naite/lib/utils/editor-navigation.ts
+++ b/packages/vscode-extension/src/naite/lib/utils/editor-navigation.ts
@@ -2,13 +2,23 @@ import vscode from "vscode";
 
 /**
  * 파일의 특정 라인으로 이동하고 화면 중앙에 표시
+ *
+ * @param filePath - 이동할 파일의 절대 경로
+ * @param lineNumber - 이동할 라인 번호 (1-based)
+ * @returns 성공 시 true, 실패 시 false
  */
-export async function goToLocation(filePath: string, lineNumber: number): Promise<void> {
-  const uri = vscode.Uri.file(filePath);
-  const doc = await vscode.workspace.openTextDocument(uri);
-  const editor = await vscode.window.showTextDocument(doc, vscode.ViewColumn.One);
-  const line = lineNumber - 1;
-  const position = new vscode.Position(line, 0);
-  editor.selection = new vscode.Selection(position, position);
-  editor.revealRange(new vscode.Range(position, position), vscode.TextEditorRevealType.InCenter);
+export async function goToLocation(filePath: string, lineNumber: number): Promise<boolean> {
+  try {
+    const uri = vscode.Uri.file(filePath);
+    const doc = await vscode.workspace.openTextDocument(uri);
+    const editor = await vscode.window.showTextDocument(doc, vscode.ViewColumn.One);
+    const line = lineNumber - 1;
+    const position = new vscode.Position(line, 0);
+    editor.selection = new vscode.Selection(position, position);
+    editor.revealRange(new vscode.Range(position, position), vscode.TextEditorRevealType.InCenter);
+    return true;
+  } catch (err) {
+    console.error(`[goToLocation] Failed to open ${filePath}:${lineNumber}:`, err);
+    return false;
+  }
 }


### PR DESCRIPTION
## 🤖 AI 생성 PR 안내

이 PR은 AI(Claude Code)가 코드베이스를 분석하여 생성한 Nightly PR입니다.
#6(Nightly PR Directions)과 #7(내일 새벽에 AI에게 맡길 일들)의 지침을 따라 작업했습니다.

---

## Summary

- **goToLocation 에러 핸들링 추가**: 파일 열기 실패 시 예외를 catch하여 로깅 후 false 반환
- **TraceStore.addRunEnd() 타이머 정리**: run/end 메시지 수신 시 남아있는 디바운스 타이머를 정리
- **NaiteTraceViewerProvider 타이머/리스너 정리**: dispose 시 타이머 정리, restorePanel 시 중복 등록 방지

---

## 상세 내용

### 1. packages/vscode-extension/src/naite/lib/utils/editor-navigation.ts

**문제점**:
- `goToLocation()` 함수가 파일 열기 실패 시 예외를 던지지만, 호출자가 이를 처리하지 않음
- 예외가 unhandled promise rejection으로 전파되어 확장의 안정성에 영향을 줄 수 있음
- 존재하지 않는 파일 경로가 전달되거나, 권한 문제가 있을 때 발생 가능

**수정 내용**:
- try-catch로 감싸서 예외를 catch
- 실패 시 에러를 로깅하고 false를 반환
- 성공 시 true를 반환
- JSDoc에 파라미터와 반환값 설명 추가

### 2. packages/sonamu-lsp/src/core/trace-store.ts

**문제점**:
- `addTestResult()`에서 100ms 디바운스 타이머를 설정하지만, `addRunEnd()`에서 이를 정리하지 않음
- 테스트 실행이 끝나도 타이머가 남아있을 수 있음
- 마지막 테스트 결과가 run/end 이후에 알림될 수 있음

**수정 내용**:
- `addRunEnd()`에서 남아있는 디바운스 타이머를 확인하고 정리
- 타이머가 있으면 즉시 `notifyTestResultAdded()` 호출하여 마지막 결과를 즉시 알림

**참고**: PR #31에서 같은 문제를 다루고 있으나, `packages/extension/` 경로를 사용하고 있어 현재 main 브랜치(`packages/sonamu-lsp/`)에 적용되지 않았습니다.

### 3. packages/vscode-extension/src/naite/features/trace-viewer/trace-viewer-provider.ts

**문제점**:
- `focusKey()`, `focusTest()` 메서드의 setTimeout 타이머가 dispose 시 정리되지 않음
- 패널이 닫혀도 타이머가 남아 메시지 전송 시도 가능
- `restorePanel()` 호출 시 기존 이벤트 리스너가 정리되지 않아 중복 등록됨
- 빠른 연속 호출 시 타이머가 누적됨

**수정 내용**:
- `_focusKeyTimeout`, `_focusTestTimeout` 필드 추가
- `focusKey()`, `focusTest()`에서 이전 타이머를 취소하고 새 타이머 설정
- `_clearDisposables()` 메서드 추가: `_setupPanel()` 시작 시 기존 disposables 정리
- `_clearTimeouts()` 메서드 추가: 타이머 일괄 정리
- `dispose()` 메서드에서 타이머와 disposables 모두 정리

**참고**: PR #32에서 같은 문제를 다루고 있으나, `packages/extension/` 경로를 사용하고 있어 현재 main 브랜치(`packages/vscode-extension/`)에 적용되지 않았습니다.

---

## 왜 이 작업을 선정했는가

Issue #7의 지침에 따라 분석했습니다:
- "코드에 예상치 못한 동작이나 버그 등 잠재적으로 위험한 포인트가 존재하는 경우 → 식별하고 제거해야 합니다."

**잠재적 위험 포인트 분석**:
1. `goToLocation`: 파일 열기 실패가 unhandled rejection으로 전파
2. `TraceStore.addRunEnd`: 타이머 미정리로 인한 예측 불가능한 알림 타이밍
3. `NaiteTraceViewerProvider`: 타이머/리스너 누수로 인한 메모리 누수 및 중복 동작

---

## 변경하지 않으면 어떤 점이 안 좋은지

1. **goToLocation**: 
   - 존재하지 않는 파일 경로로 이동 시 확장이 예외를 던짐
   - VSCode 출력 패널에 에러가 표시되어 사용자 혼란
   
2. **TraceStore.addRunEnd**:
   - 마지막 테스트 결과가 run/end 이후 100ms 후에 알림됨
   - 불필요한 타이머가 남아있어 리소스 점유
   
3. **NaiteTraceViewerProvider**:
   - 패널 닫힘 후에도 타이머가 실행되어 좀비 메시지 발송 시도
   - VSCode 재시작 후 restorePanel 시 리스너가 중복 등록됨
   - 빠른 연속 호출 시 여러 타이머가 동시에 실행됨

---

## 영향 범위

- **기능적 영향**: 
  - goToLocation 호출자는 이제 성공/실패 여부를 알 수 있음 (하지만 현재 호출자는 반환값을 사용하지 않으므로 하위 호환)
  - run/end 시 마지막 결과가 더 빨리 반영됨
  - 패널 열기/닫기 반복 시 메모리 누수 방지
- **타입 체크**: ✅ 통과
- **린트**: ✅ 통과
- **빌드**: ✅ 통과
- **테스트**: ✅ 23개 테스트 모두 통과

---

## 확인 방법

1. **goToLocation**: 
   - Trace Viewer에서 존재하지 않는 파일 경로의 trace 클릭
   - 콘솔에 에러 로그가 표시되고 확장이 정상 동작하는지 확인

2. **TraceStore.addRunEnd**: 
   - 테스트 실행 후 run/end 메시지 수신 직후 마지막 결과가 반영되는지 확인
   - 기존보다 응답이 빨라야 함

3. **NaiteTraceViewerProvider**:
   - 패널 열기/닫기 반복 후 메모리 사용량 확인
   - VSCode 재시작 후 패널 복원 시 정상 동작 확인

---

## 참조한 이슈 및 PR

- #6 (Nightly PR Directions)
- #7 (내일 새벽에 AI에게 맡길 일들)
- #31 (TraceStore.addRunEnd 타이머 정리 - 경로 불일치로 적용되지 않음)
- #32 (타이머 정리 및 리스너 중복 등록 방지 - 경로 불일치로 적용되지 않음)

---

## 사람의 확인이 필요한 부분

- `goToLocation` 반환 타입 변경이 하위 호환에 영향이 없는지 확인 필요
  - 현재 호출자(trace-viewer-provider.ts:67)는 반환값을 사용하지 않으므로 영향 없음

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)