### PR TITLE
[Nightly 2026-02-13] scanDebounceMap 메모리 누수 방지 및 CLAUDE.md 문서 보완

### DIFF
--- a/packages/sonamu-lsp/src/server.ts
+++ b/packages/sonamu-lsp/src/server.ts
@@ -143,8 +143,11 @@ function debouncedScanAndUpdate(document: TextDocument): void {
   scanDebounceMap.set(
     key,
     setTimeout(() => {
-      scanAndUpdate(document);
-      scanDebounceMap.delete(key);
+      try {
+        scanAndUpdate(document);
+      } finally {
+        scanDebounceMap.delete(key);
+      }
     }, 200),
   );
 }

--- a/packages/vscode-extension/CLAUDE.md
+++ b/packages/vscode-extension/CLAUDE.md
@@ -34,7 +34,12 @@ src/
     ├── features/
     │   ├── trace-viewer/         # 웹뷰 프로바이더 (trace-viewer-provider.ts)
     │   ├── key-highlighting/     # 키 데코레이션 (key-decorator.ts, 자체 정규식 기반)
-    │   └── inline-value-display/ # 인라인 값 표시 (value-decorator.ts, LSP inlay hints 활용)
+    │   ├── inline-value-display/ # 인라인 값 표시 (value-decorator.ts, LSP inlay hints 활용)
+    │   ├── key-completion/       # README만 존재 (실제 구현은 sonamu-lsp)
+    │   ├── key-hover-info-box/   # README만 존재 (실제 구현은 sonamu-lsp)
+    │   ├── key-navigation/       # README만 존재 (실제 구현은 sonamu-lsp)
+    │   ├── key-symbol-search/    # README만 존재 (실제 구현은 sonamu-lsp)
+    │   └── key-undefined-warning/# README만 존재 (실제 구현은 sonamu-lsp)
     └── lib/
         └── utils/
             ├── editor-navigation.ts  # 에디터 파일 열기/이동


### PR DESCRIPTION
## 🤖 AI 생성 PR 안내

이 PR은 AI(Claude Code)가 코드베이스를 분석하여 생성한 Nightly PR입니다.
#6(Nightly PR Directions)과 #7(내일 새벽에 AI에게 맡길 일들)의 지침을 따라 작업했습니다.

---

## Summary

- **scanDebounceMap 메모리 누수 방지**: debouncedScanAndUpdate 함수에서 예외 발생 시에도 맵 정리가 되도록 수정
- **CLAUDE.md features 디렉토리 구조 보완**: 실제 존재하는 feature 디렉토리들을 문서에 추가

---

## 상세 내용

### 1. packages/sonamu-lsp/src/server.ts

**문제점**:
- `debouncedScanAndUpdate()` 함수에서 setTimeout 콜백 내부의 `scanAndUpdate(document)` 실행 중 예외가 발생하면 `scanDebounceMap.delete(key)`가 호출되지 않음
- 에러 발생 시 맵에 고아(orphaned) 엔트리가 남아 메모리 누수 발생 가능
- 문서를 여러 번 열고 닫으면서 에러가 발생할 경우 맵이 계속 커질 수 있음

**수정 내용**:
```typescript
setTimeout(() => {
  try {
    scanAndUpdate(document);
  } finally {
    scanDebounceMap.delete(key);  // 항상 실행
  }
}, 200)
```

### 2. packages/vscode-extension/CLAUDE.md

**문제점**:
- CLAUDE.md의 features 디렉토리 구조 설명이 불완전함
- 실제로는 8개의 feature 디렉토리가 있지만, 문서에는 3개만 기술되어 있었음
- 누락된 디렉토리들: key-completion, key-hover-info-box, key-navigation, key-symbol-search, key-undefined-warning

**수정 내용**:
- 누락된 5개 feature 디렉토리를 문서에 추가
- 해당 기능들의 실제 구현이 sonamu-lsp에 있음을 명시

---

## 왜 이 작업을 선정했는가

Issue #7의 지침에 따라 분석했습니다:
- "코드에 예상치 못한 동작이나 버그 등 잠재적으로 위험한 포인트가 존재하는 경우 → 식별하고 제거해야 합니다."
- "문서와 주석이 코드와 어긋나는 경우 → 설명이 코드와 명백히 다를 경우 설명을 업데이트해야 합니다."

**분석 과정**:
1. 코드베이스 전반에 걸쳐 타이머/리소스 정리, 에러 핸들링 누락 등을 탐색
2. 문서와 코드의 불일치 확인
3. 기존 Nightly PR들(#35, #36 등)에서 이미 다룬 내용은 제외

---

## 변경하지 않으면 어떤 점이 안 좋은지

1. **scanDebounceMap**: 
   - 문서 스캔 중 예외 발생 시 맵 엔트리가 정리되지 않음
   - 장시간 사용 시 메모리 사용량 증가 가능
   - 동일 문서에 대한 후속 디바운스가 정상 동작하지 않을 수 있음

2. **CLAUDE.md**:
   - 개발자가 코드베이스를 파악할 때 혼란 발생
   - 실제 디렉토리 구조와 문서가 다르면 신뢰도 저하
   - AI 에이전트가 문서를 참고할 때 잘못된 정보를 얻을 수 있음

---

## 영향 범위

- **기능적 영향**: LSP 서버의 문서 스캔 안정성 향상
- **하위 호환성**: 기존 동작에 영향 없음 (에러 케이스에서만 동작 개선)
- **타입 체크**: ✅ 통과
- **린트**: ✅ 통과
- **빌드**: ✅ 통과

---

## 확인 방법

1. **scanDebounceMap 수정 확인**:
   - sonamu-lsp 코드에서 scanAndUpdate 함수 내부에서 의도적으로 예외를 발생시킴
   - 이전: scanDebounceMap에 키가 남아있음
   - 이후: finally 블록에서 키가 삭제됨

2. **CLAUDE.md 확인**:
   - `ls packages/vscode-extension/src/naite/features/` 실행
   - 문서의 디렉토리 목록과 실제 디렉토리 비교

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)